### PR TITLE
Support variable framerate videos

### DIFF
--- a/packages/minimp4/src/writer.rs
+++ b/packages/minimp4/src/writer.rs
@@ -1,5 +1,10 @@
 use super::c::{mp4_h26x_write_nal, mp4_h26x_writer_t};
 
+pub enum TimestampSource {
+    Fps(u32),
+    Duration(std::time::Duration),
+}
+
 fn get_nal_size(buf: &mut [u8], size: usize) -> usize {
     let mut pos = 3;
     while size - pos > 3 {
@@ -14,7 +19,7 @@ fn get_nal_size(buf: &mut [u8], size: usize) -> usize {
     size
 }
 
-pub fn write_mp4(mp4wr: &mut mp4_h26x_writer_t, fps: i32, data: &[u8]) {
+pub fn write_mp4(mp4wr: &mut mp4_h26x_writer_t, timestamp_source: TimestampSource, data: &[u8]) {
     let mut data_size = data.len();
     let mut data_ptr = data.as_ptr();
 
@@ -26,7 +31,11 @@ pub fn write_mp4(mp4wr: &mut mp4_h26x_writer_t, fps: i32, data: &[u8]) {
             data_size -= 1;
             continue;
         }
-        unsafe { mp4_h26x_write_nal(mp4wr, data_ptr, nal_size as i32, (90000 / fps) as u32) };
+        let next_timestamp_90khz = match timestamp_source {
+            TimestampSource::Fps(fps) => 90000 / fps,
+            TimestampSource::Duration(duration) => (duration * 90).as_millis().try_into().unwrap(),
+        };
+        unsafe { mp4_h26x_write_nal(mp4wr, data_ptr, nal_size as i32, next_timestamp_90khz) };
         data_ptr = unsafe { data_ptr.add(nal_size) };
         data_size -= nal_size;
     }


### PR DESCRIPTION
Hi, first of all thanks for maintaining this crate, it helped me a lot!
One feature was missing for me, namely muxing video samples with variable duration. For use cases where the framerate isn't constant, eg. live video feeds, we want to show some frames for longer and other for a shorter period of time – sometimes frames come at rate 1 every couple of seconds (when nothing happens on the screen), sometimes they come at 60 FPS (when there's lot of movement).
This PR introduces `write_video_with_duration`, which allows to write video frames with specific duration for such use cases.